### PR TITLE
Move secrets to env vars

### DIFF
--- a/CRM.Web/appsettings.json
+++ b/CRM.Web/appsettings.json
@@ -7,22 +7,18 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    //"ConnectionString": "Data Source=.;Initial Catalog=CRM;Integrated Security=True;Encrypt=True;TrustServerCertificate=True",
-    //"ProjectDbContextConnection": "Server=(localdb)\\mssqllocaldb;Database=CRM.UI;Trusted_Connection=True;MultipleActiveResultSets=true",
 
-    "ConnectionString": "Data Source=44.195.253.114;Initial Catalog=roboboti_crm;User ID=roboboti_crm_admin;Password=21Xi0vr#2;Integrated Security=false;Encrypt=True;TrustServerCertificate=True",
-    "ProjectDbContextConnection": "Server=44.195.253.114;Database=CRM.UI;Trusted_Connection=True;MultipleActiveResultSets=true"
+    "ConnectionString": "${ConnectionStrings__ConnectionString}",
+    "ProjectDbContextConnection": "${ConnectionStrings__ProjectDbContextConnection}"
 
   },
   "ApiSettings": {
-    //"ApiUrl": "https://api-monitor.robobotics.eu"
     "ApiUrl": "https://localhost:44300/"
   },
   "Jwt": {
     "Issuer": "CRMWebApp",
-    //"Audience": "https://monitor.robobotics.eu/",
-    "Audience": "https://localhost:44332/",
-    "SecretKey": "a7b4cf1a-b3e2-4d87-8f9a-82c6a7b5f6d2",
+    "Audience": "https://monitor.robobotics.eu/",
+    "SecretKey": "${Jwt__Key}",
     "ExpireDays": 30
   },
   "SmtpSettings": {

--- a/CRM/appsettings.json
+++ b/CRM/appsettings.json
@@ -7,18 +7,15 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    //"ConnectionString": "Data Source=.;Initial Catalog=Roboboti;Integrated Security=True;Encrypt=True;TrustServerCertificate=True"
-    //"ConnectionString": "Data Source=194.233.83.76;Initial Catalog=SKDDB;User ID=EPARKUSER;Password=zq0U5b@95;Integrated Security=false;Encrypt=True;TrustServerCertificate=True",
-    "ConnectionString": "Server=44.195.253.114;Database=roboboti_crm;User Id=roboboti_crm_admin;Password=21Xi0vr#2;Integrated Security=false;Encrypt=True;TrustServerCertificate=True"
+    "ConnectionString": "${ConnectionStrings__ConnectionString}"
   },
 
 
   "Jwt": {
     "Issuer": "CRMWebApp",
-    "Audience": "https://localhost:44332/",
-    //"Audience": "https://monitor.robobotics.eu/",
-    "Key": "a7b4cf1a-b3e2-4d87-8f9a-82c6a7b5f6d2",
-    "ExpiryInMinutes": 43200 //30days 
+        "Audience": "https://monitor.robobotics.eu/",
+    "Key": "${Jwt__Key}",
+    "ExpiryInMinutes": 43200 
   }
 
 }


### PR DESCRIPTION
## Summary
- clean comments from appsettings
- use env var placeholders for secrets
- set JWT audiences to production URLs

## Testing
- `dotnet build CRM.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_b_68683c075760832a99c0f7055ed908d9