### PR TITLE
Configure ApiClient base URL

### DIFF
--- a/CRM.Web/Program.cs
+++ b/CRM.Web/Program.cs
@@ -77,11 +77,14 @@ builder.Services.Configure<ApiSettings>(builder.Configuration.GetSection("ApiSet
 builder.Services.AddHttpContextAccessor(); // Allows accessing HTTP context (cookies, etc.)
 builder.Services.AddTransient<CustomAuthorizationHandler>();
 
-builder.Services.AddHttpClient("ApiClient", client =>
+builder.Services.AddHttpClient("ApiClient", (sp, client) =>
 {
-
-    client.BaseAddress = new Uri("https://localhost:44300"); // Replace with your API base URL
-                                                             // client.BaseAddress = new Uri("https://api-monitor.robobotics.eu"); // Replace with your API base URL
+    var configuration = sp.GetRequiredService<IConfiguration>();
+    var apiUrl = configuration.GetValue<string>("ApiSettings:ApiUrl");
+    if (!string.IsNullOrWhiteSpace(apiUrl))
+    {
+        client.BaseAddress = new Uri(apiUrl);
+    }
 }).AddHttpMessageHandler<CustomAuthorizationHandler>();
 
 var app = builder.Build();

--- a/CRM.Web/ViewComponents/MenuViewComponent.cs
+++ b/CRM.Web/ViewComponents/MenuViewComponent.cs
@@ -20,9 +20,8 @@ public class MenuViewComponent : ViewComponent
         if (string.IsNullOrEmpty(token))
             return View(new List<Menus>());
 
-        var client = _httpClientFactory.CreateClient();
-        //client.BaseAddress = new Uri("https://api-monitor.robobotics.eu"); // API base URL
-        client.BaseAddress = new Uri("https://localhost:44332/");
+        // Use the named client configured with the API base address
+        var client = _httpClientFactory.CreateClient("ApiClient");
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
         var response = await client.GetAsync("api/Menu/usermenus");


### PR DESCRIPTION
## Summary
- read ApiSettings:ApiUrl and use it to configure the ApiClient's base address
- get API base URL from the named HttpClient in MenuViewComponent

## Testing
- `dotnet build CRM.sln`

------
https://chatgpt.com/codex/tasks/task_b_68683f892ce0832a8b1b78385168cc16