### PR TITLE
Fix sidebar menu markup

### DIFF
--- a/CRM.Web/Pages/Shared/_Layout.cshtml
+++ b/CRM.Web/Pages/Shared/_Layout.cshtml
@@ -98,10 +98,6 @@
                 <div class="menu-inner-shadow"></div>
                 <ul class="menu-inner py-1 ps ps--active-y" id="sidebarMenuContainer">
                     @await Component.InvokeAsync("Menu")
-                </ul>
-
-
-                <ul class="menu-inner py-1 ps ps--active-y">
                     @if (userRole != null)
                     {
                         <!-- Cards -->


### PR DESCRIPTION
## Summary
- merge dynamic menu and static items into a single `<ul>` to avoid extra spacing

## Testing
- `dotnet build CRM.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_686841e7a8b0832aa064e50c70c904b8