### PR TITLE
Adjust cookie security settings based on environment

### DIFF
--- a/CRM.Web/Areas/Identity/Pages/Account/Login.cshtml.cs
+++ b/CRM.Web/Areas/Identity/Pages/Account/Login.cshtml.cs
@@ -161,7 +161,7 @@ namespace CRM.UI.Areas.Identity.Pages.Account
                         {
                             //HttpOnly = false,
                             HttpOnly = true,
-                            Secure = true,
+                            Secure = Request.IsHttps,
                             SameSite = SameSiteMode.Strict,
                             Expires = DateTimeOffset.UtcNow.AddDays(30)
                         };

--- a/CRM.Web/Program.cs
+++ b/CRM.Web/Program.cs
@@ -104,7 +104,9 @@ var cookiePolicyOptions = new CookiePolicyOptions
 {
     MinimumSameSitePolicy = SameSiteMode.Strict,
     HttpOnly = Microsoft.AspNetCore.CookiePolicy.HttpOnlyPolicy.Always,
-    Secure = CookieSecurePolicy.None,
+    Secure = builder.Environment.IsDevelopment()
+        ? CookieSecurePolicy.SameAsRequest
+        : CookieSecurePolicy.Always,
 };
 app.UseCookiePolicy(cookiePolicyOptions);
 app.UseMiddleware<JwtAuthenticationMiddleware>();

--- a/CRM/Controllers/AccountController.cs
+++ b/CRM/Controllers/AccountController.cs
@@ -77,7 +77,7 @@ namespace CRM.Controllers
                 Response.Cookies.Append("jwt", token, new CookieOptions
                 {
                     HttpOnly = true,
-                    Secure = true,
+                    Secure = Request.IsHttps,
                     SameSite = SameSiteMode.Lax,
                     Expires = DateTimeOffset.UtcNow.AddDays(30)
                 });


### PR DESCRIPTION
## Summary
- use `Request.IsHttps` when setting cookies in login pages
- secure cookies via cookie policy when environment is not development
- ensure AccountController cookie settings respect the current request

## Testing
- `dotnet build CRM.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_b_686843a96908832a9adeb006febcbe58