### PR TITLE
Add status field for machines

### DIFF
--- a/CRM.Data/Entities/Machine.cs
+++ b/CRM.Data/Entities/Machine.cs
@@ -16,6 +16,8 @@ namespace CRM.Data.Entities
         public string Username { get; set; }
         public string Password { get; set; }
 
+        public bool Status { get; set; }
+
         // Navigation Property
         public Client? Client { get; set; }
     }

--- a/CRM.Web/Pages/Machines.cshtml
+++ b/CRM.Web/Pages/Machines.cshtml
@@ -26,6 +26,7 @@
                 <th>MachineIp</th>
                 <th>Username</th>
                 <th>Password</th>
+                <th>Status</th>
                 <th>Action</th>
             </tr>
         </thead>
@@ -73,7 +74,13 @@
                         <div class="col mb-2">
 
                             <input type="text" asp-for="MachineModel.Password" class="form-control" placeholder="Enter Password">
-                            
+
+                        </div>
+                    </div>
+                    <div class="row g-2">
+                        <div class="form-check mb-2">
+                            <input class="form-check-input" type="checkbox" asp-for="MachineModel.Status" id="MachineModel_Status" />
+                            <label class="form-check-label" for="MachineModel_Status">Connected</label>
                         </div>
                     </div>
                 </div>
@@ -115,6 +122,12 @@
                             // The actual password is stored as a data attribute.
                             return `<span class="password-mask" data-password="${data}">*******</span>
                                 <i class="fas fa-eye toggle-password" style="cursor: pointer; margin-left: 5px;"></i>`;
+                        }
+                    },
+                    {
+                        data: 'status',
+                        render: function (data) {
+                            return data ? 'Connected' : 'Not Connected';
                         }
                     },
                     {
@@ -160,6 +173,7 @@
                 $('#MachineModel_MachineIp').val(data.machineIp);
                 $('#MachineModel_Username').val(data.username);
                 $('#MachineModel_Password').val(data.password);
+                $('#MachineModel_Status').prop('checked', data.status);
 
                 $('#modalTitle').text('Edit Machine');
                 $('#machineModal').modal('show');
@@ -174,7 +188,8 @@
                     ClientId: $('#MachineModel_ClientId').val(),
                     MachineIp: $('#MachineModel_MachineIp').val(),
                     Username: $('#MachineModel_Username').val(),
-                    Password: $('#MachineModel_Password').val()
+                    Password: $('#MachineModel_Password').val(),
+                    Status: $('#MachineModel_Status').is(':checked')
                 };
 
                 // Send POST request to update the machine

--- a/CRM.Web/Pages/Machines.cshtml.cs
+++ b/CRM.Web/Pages/Machines.cshtml.cs
@@ -243,5 +243,6 @@ namespace CRM.Web.Pages
         public string Username { get; set; }
         public string Password { get; set; }
         public Client Client { get; set; }
+        public bool Status { get; set; }
     }
 }

--- a/CRM/Controllers/MachineController.cs
+++ b/CRM/Controllers/MachineController.cs
@@ -195,5 +195,29 @@ namespace CRM.Controllers
             }
         }
 
+        [HttpPost("UpdateStatus")]
+        [AllowAnonymous]
+        public async Task<IActionResult> UpdateStatus(int clientId, string machineIp, bool status)
+        {
+            try
+            {
+                var machine = await _unitOfWork.MachineRepository.GetByIdAsync(m =>
+                    m.ClientId == clientId && m.MachineIp.Contains(machineIp));
+
+                if (machine == null)
+                    return NotFound();
+
+                machine.Status = status;
+                await _unitOfWork.MachineRepository.UpdateAsync(machine);
+                await _unitOfWork.SaveChangesAsync();
+
+                return Ok(machine);
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(500, $"Internal server error: {ex.Message}");
+            }
+        }
+
     }
 }


### PR DESCRIPTION
## Summary
- allow Machine entities to store a boolean `Status`
- show Status as a checkbox in machine modal
- display connection status in the machines table
- add API endpoint to update machine status by client id and machine ip

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_686a83f85898832abff08bc0c7481121