### PR TITLE
Fix OnGetAsync in machine page

### DIFF
--- a/CRM.Web/Pages/Machines.cshtml.cs
+++ b/CRM.Web/Pages/Machines.cshtml.cs
@@ -41,20 +41,33 @@ namespace CRM.Web.Pages
         {
 
             MachineModel = new MachineModel();
-            // Get the list of clients from your service or repository
             var httpClient = _httpClientFactory.CreateClient("ApiClient");
-            
-                AddAuthorizationToken(httpClient); 
-                var response = await httpClient.GetAsync("/api/Clients");
-              
 
-                if (response.IsSuccessStatusCode)
-                {
-                    var content = await response.Content.ReadAsStringAsync();
-                    Clients = JsonConvert.DeserializeObject<List<ClientModel>>(content);
-                } 
-                 
-            //Clients = new List<ClientModel>();
+            AddAuthorizationToken(httpClient);
+
+            // Load machines
+            var machineResponse = await httpClient.GetAsync(apiEndpoint);
+            if (machineResponse.IsSuccessStatusCode)
+            {
+                var machineContent = await machineResponse.Content.ReadAsStringAsync();
+                Machines = JsonConvert.DeserializeObject<List<MachineModel>>(machineContent);
+            }
+            else
+            {
+                Machines = new List<MachineModel>();
+            }
+
+            // Load clients for dropdown
+            var clientResponse = await httpClient.GetAsync("/api/Clients");
+            if (clientResponse.IsSuccessStatusCode)
+            {
+                var content = await clientResponse.Content.ReadAsStringAsync();
+                Clients = JsonConvert.DeserializeObject<List<ClientModel>>(content);
+            }
+            else
+            {
+                Clients = new List<ClientModel>();
+            }
 
         }
         public async Task<IActionResult> OnPost()


### PR DESCRIPTION
## Summary
- fetch machine list in `Machines` page OnGetAsync
- keep client drop-down data

## Testing
- `dotnet` unavailable; build/test skipped

------
https://chatgpt.com/codex/tasks/task_b_686c1be74b0c832abbaa184a0bd694ba