### PR TITLE
Fix Machines update form encoding

### DIFF
--- a/CRM.Web/Pages/Machines.cshtml
+++ b/CRM.Web/Pages/Machines.cshtml
@@ -196,8 +196,7 @@
                 $.ajax({
                     url: "/Machines?handler=Update",
                     type: "POST",
-                    contentType: "application/json",
-                    data: JSON.stringify(formData),
+                    data: formData,
                     beforeSend: function (xhr) {
                         xhr.setRequestHeader('XSRF-TOKEN', $('input[name="__RequestVerificationToken"]').val());
                     },


### PR DESCRIPTION
## Summary
- remove JSON content type from update AJAX request in `Machines.cshtml`

## Testing
- `dotnet test CRM.sln` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_686c24a2ef74832a974ac74f6468a6cb